### PR TITLE
fix compile error

### DIFF
--- a/rosesong-cli/rosesong/player/network.rs
+++ b/rosesong-cli/rosesong/player/network.rs
@@ -1,8 +1,7 @@
 use crate::bilibili::fetch_audio_url::fetch_audio_url;
 use crate::error::ApplicationError;
 use glib::object::ObjectExt;
-use gstreamer::prelude::{ElementExtManual, GstBinExtManual};
-use gstreamer::traits::{ElementExt, PadExt};
+use gstreamer::prelude::{ElementExt, ElementExtManual, GstBinExtManual, PadExt};
 use gstreamer::Pipeline;
 use log::{error, info};
 use reqwest::header::{ACCEPT, RANGE, USER_AGENT};


### PR DESCRIPTION
在最新的编译器上编译出现错误，修复
```
error[E0603]: module `traits` is private
  --> rosesong/player/network.rs:5:16
   |
5  | use gstreamer::traits::{ElementExt, PadExt};
   |                ^^^^^^ private module
   |
help: consider importing this trait instead:
      gstreamer::prelude::ElementExt
  --> rosesong/player/network.rs:5:25
   |
5  | use gstreamer::traits::{ElementExt, PadExt};
   |                         ^^^^^^^^^^
note: the module `traits` is defined here
  --> /home/oveln/.cargo/registry/src/index.crates.io-6f17d22bba15001f/gstreamer-0.22.7/src/lib.rs:44:9
   |
44 | pub use crate::auto::*;
   |         ^^^^^^^^^^^

error[E0603]: module `traits` is private
  --> rosesong/player/network.rs:5:16
   |
5  | use gstreamer::traits::{ElementExt, PadExt};
   |                ^^^^^^ private module
   |
help: consider importing this trait instead:
      gstreamer::prelude::PadExt
  --> rosesong/player/network.rs:5:37
   |
5  | use gstreamer::traits::{ElementExt, PadExt};
   |                                     ^^^^^^
note: the module `traits` is defined here
  --> /home/oveln/.cargo/registry/src/index.crates.io-6f17d22bba15001f/gstreamer-0.22.7/src/lib.rs:44:9
   |
44 | pub use crate::auto::*;
   |         ^^^^^^^^^^^

error[E0599]: no method named `connect_pad_added` found for struct `gstreamer::Element` in the current scope
   --> rosesong/player/network.rs:97:15
    |
97  |     decodebin.connect_pad_added(move |_, src_pad| {
    |     ----------^^^^^^^^^^^^^^^^^
    |
   ::: /home/oveln/.cargo/registry/src/index.crates.io-6f17d22bba15001f/gstreamer-0.22.7/src/auto/element.rs:523:8
    |
523 |     fn connect_pad_added<F: Fn(&Self, &Pad) + Send + Sync + 'static>(
    |        ----------------- the method is available for `gstreamer::Element` here
    |
    = help: items from traits can only be used if the trait is in scope
help: trait `ElementExt` which provides `connect_pad_added` is implemented but not in scope; perhaps you want to import it
    |
1   + use gstreamer::prelude::ElementExt;
    |
help: there is a method `connect_pad_removed` with a similar name
    |
97  |     decodebin.connect_pad_removed(move |_, src_pad| {
    |               ~~~~~~~~~~~~~~~~~~~

error[E0599]: no method named `sync_state_with_parent` found for struct `gstreamer::Element` in the current scope
   --> rosesong/player/network.rs:114:18
    |
113 | /             audioconvert
114 | |                 .sync_state_with_parent()
    | |                 -^^^^^^^^^^^^^^^^^^^^^^ method not found in `Element`
    | |_________________|
    |
    |
   ::: /home/oveln/.cargo/registry/src/index.crates.io-6f17d22bba15001f/gstreamer-0.22.7/src/auto/element.rs:466:8
    |
466 |       fn sync_state_with_parent(&self) -> Result<(), glib::error::BoolError> {
    |          ---------------------- the method is available for `gstreamer::Element` here
    |
    = help: items from traits can only be used if the trait is in scope
help: trait `ElementExt` which provides `sync_state_with_parent` is implemented but not in scope; perhaps you want to import it
    |
1   + use gstreamer::prelude::ElementExt;
    |

error[E0599]: no method named `sync_state_with_parent` found for struct `gstreamer::Element` in the current scope
   --> rosesong/player/network.rs:117:18
    |
116 | /             audioresample
117 | |                 .sync_state_with_parent()
    | |                 -^^^^^^^^^^^^^^^^^^^^^^ method not found in `Element`
    | |_________________|
    |
    |
   ::: /home/oveln/.cargo/registry/src/index.crates.io-6f17d22bba15001f/gstreamer-0.22.7/src/auto/element.rs:466:8
    |
466 |       fn sync_state_with_parent(&self) -> Result<(), glib::error::BoolError> {
    |          ---------------------- the method is available for `gstreamer::Element` here
    |
    = help: items from traits can only be used if the trait is in scope
help: trait `ElementExt` which provides `sync_state_with_parent` is implemented but not in scope; perhaps you want to import it
    |
1   + use gstreamer::prelude::ElementExt;
    |

error[E0599]: no method named `sync_state_with_parent` found for struct `gstreamer::Element` in the current scope
   --> rosesong/player/network.rs:120:18
    |
119 | /             autoaudiosink
120 | |                 .sync_state_with_parent()
    | |                 -^^^^^^^^^^^^^^^^^^^^^^ method not found in `Element`
    | |_________________|
    |
    |
   ::: /home/oveln/.cargo/registry/src/index.crates.io-6f17d22bba15001f/gstreamer-0.22.7/src/auto/element.rs:466:8
    |
466 |       fn sync_state_with_parent(&self) -> Result<(), glib::error::BoolError> {
    |          ---------------------- the method is available for `gstreamer::Element` here
    |
    = help: items from traits can only be used if the trait is in scope
help: trait `ElementExt` which provides `sync_state_with_parent` is implemented but not in scope; perhaps you want to import it
    |
1   + use gstreamer::prelude::ElementExt;
    |

error[E0599]: no method named `static_pad` found for struct `gstreamer::Element` in the current scope
   --> rosesong/player/network.rs:124:18
    |
123 |               let audio_pad = audioconvert
    |  _____________________________-
124 | |                 .static_pad("sink")
    | |                 -^^^^^^^^^^ method not found in `Element`
    | |_________________|
    |
    |
   ::: /home/oveln/.cargo/registry/src/index.crates.io-6f17d22bba15001f/gstreamer-0.22.7/src/auto/element.rs:307:8
    |
307 |       fn static_pad(&self, name: &str) -> Option<Pad> {
    |          ---------- the method is available for `gstreamer::Element` here
    |
    = help: items from traits can only be used if the trait is in scope
help: trait `ElementExt` which provides `static_pad` is implemented but not in scope; perhaps you want to import it
    |
1   + use gstreamer::prelude::ElementExt;
    |

error[E0599]: no method named `set_state` found for reference `&Pipeline` in the current scope
   --> rosesong/player/network.rs:141:14
    |
141 |     pipeline.set_state(gstreamer::State::Playing).map_err(|_| {
    |              ^^^^^^^^^
    |
    = help: items from traits can only be used if the trait is in scope
help: trait `ElementExt` which provides `set_state` is implemented but not in scope; perhaps you want to import it
    |
1   + use gstreamer::prelude::ElementExt;
    |
help: there is a method `state` with a similar name
    |
141 |     pipeline.state(gstreamer::State::Playing).map_err(|_| {
    |              ~~~~~

Some errors have detailed explanations: E0599, E0603.
For more information about an error, try `rustc --explain E0599`.
error: could not compile `rosesong` (bin "rosesong") due to 8 previous errors
warning: build failed, waiting for other jobs to finish...


```